### PR TITLE
fix: [DBI-478] Fix SDK Target Framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
-.PHONY: generate-sdk sync-csharp-version
+.PHONY: generate-sdk sync-csharp-version set-dotnet9-version
 ROOT_DIR := $(shell git rev-parse --show-toplevel)
 sync-csharp-version:
 	perl -pi -e 's/"version": *"[^"]*"/"version": "9.0.203"/' ${ROOT_DIR}/global.json
+set-dotnet9-version:
+	perl -pi -e 's|<TargetFramework>net8\.0</TargetFramework>|<TargetFramework>net9.0</TargetFramework>|' $(ROOT_DIR)/src/DailyPay/SDK/DotNet9/DailyPay.SDK.DotNet9.csproj
+
 generate-sdk:
 	@echo "Generating .NET 9 SDK"
 	@speakeasy run -t csharp-9
 	@$(MAKE) sync-csharp-version
+	@$(MAKE) set-dotnet9-version

--- a/src/DailyPay/SDK/DotNet9/DailyPay.SDK.DotNet9.csproj
+++ b/src/DailyPay/SDK/DotNet9/DailyPay.SDK.DotNet9.csproj
@@ -4,7 +4,7 @@
     <IsPackable>true</IsPackable>
     <PackageId>DailyPay.SDK.DotNet9</PackageId>
     <Version>0.2.0</Version>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Authors>DailyPay, Inc.</Authors>
     <Copyright>Copyright (c) DailyPay, Inc. 2025</Copyright>
     <Description>DailyPay Public Rest API: # Welcome<br/>


### PR DESCRIPTION
### What
This fixes the Target Framework issue

### Why
NET 9 should be 9, not 8

### Related Links

* [DBI-478](https://dailypay.atlassian.net/browse/DBI-478)


[DBI-478]: https://dailypay.atlassian.net/browse/DBI-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ