### PR TITLE
fix: Set SDK generation for nightly

### DIFF
--- a/.github/workflows/sdk-generation.yaml
+++ b/.github/workflows/sdk-generation.yaml
@@ -8,7 +8,7 @@ on:
         type: boolean
         default: false
   schedule:
-    - cron: '0 * * * *' 
+    - cron: '0 0 * * *' 
 permissions:
   id-token: write
   contents: write


### PR DESCRIPTION
### What

- Set SDK generation cron to nightly

### Why

- Hourly generation not necessarily
- Will eventually be auto-triggered from the `dailypay/xapi` repository