### PR TITLE
fix[DBI-489]: Set oAuth2PasswordEnabled to false

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -15,7 +15,7 @@ generation:
     sharedErrorComponentsApr2025: true
   auth:
     oAuth2ClientCredentialsEnabled: true
-    oAuth2PasswordEnabled: true
+    oAuth2PasswordEnabled: false
   sdkHooksConfigAccess: true
   tests:
     generateTests: false


### PR DESCRIPTION
What
disable oAuth2PasswordEnabled

Why
Resource Owner Password Credentials (ROPC) flow is not supported by DailyPay auth.

Related Links
[DBI-489](https://dailypay.atlassian.net/browse/DBI-489)


[DBI-489]: https://dailypay.atlassian.net/browse/DBI-489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ