### PR TITLE
chore: migrate CODEOWNERS to new team slug infrastructure-4cn8

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @dailypay/devrel @dailypay/Integrations
-/.github/workflows @dailypay/infrastructure
+/.github/workflows @dailypay/infrastructure-4cn8


### PR DESCRIPTION
## Summary

- Replaces `@dailypay/infrastructure` with `@dailypay/infrastructure-4cn8` in CODEOWNERS
- Part of the GitHub team migration to new team slugs

## Test plan

- [ ] Verify the new team slug `infrastructure-4cn8` exists in the org
- [ ] Confirm PR reviewers are correctly assigned after merge