### PR TITLE
chore: add Bedrock meta tagging (INFRA-7255)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "CLAUDE_CODE_USE_BEDROCK": "1",
+    "ANTHROPIC_CUSTOM_HEADERS": "X-Amzn-Bedrock-Request-Metadata: {\"project\": \"dailypay-dotnet9-sdk\", \"repository\": \"dailypay/dailypay-dotnet9-sdk\"}"
+  }
+}


### PR DESCRIPTION
## Summary

Adds Bedrock request metadata tagging to this repository via `.claude/settings.json`.

When engineers use Claude Code in this repo, sessions will automatically include metadata headers that identify the project (`dailypay-dotnet9-sdk`) and repository (`dailypay/dailypay-dotnet9-sdk`). This enables usage attribution and reporting in the Bedrock Usage Dashboard.

## Changes

- Creates or updates `.claude/settings.json` with `ANTHROPIC_CUSTOM_HEADERS` containing project and repository identifiers
- Sets `CLAUDE_CODE_USE_BEDROCK=1` to ensure Bedrock routing

## Context

See [INFRA-7255](https://dailypay.atlassian.net/browse/INFRA-7255)

[INFRA-7255]: https://dailypay.atlassian.net/browse/INFRA-7255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ