### PR TITLE
fix(speakeasy): [DBI-1684] reuse a fixed PR branch for daily .NET 9 regeneration

### DIFF
--- a/.github/workflows/sdk-generation.yaml
+++ b/.github/workflows/sdk-generation.yaml
@@ -80,7 +80,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: sdk-auto-gen-dotnet9-${{ github.run_id }}
+          branch: sdk-auto-gen-dotnet9
           base: main
           commit-message: "chore: regenerate .NET 9 SDK"
           title: "chore: regenerate .NET 9 SDK - OpenAPI spec updated"


### PR DESCRIPTION
### What Changed

Changed the auto-generated PR branch in the `sdk-generation` workflow from `sdk-auto-gen-dotnet9-${{ github.run_id }}` to a fixed `sdk-auto-gen-dotnet9`.

### Why

This repo uses a custom workflow (not the Speakeasy executor) with `peter-evans/create-pull-request`. Embedding `github.run_id` in the branch name made every run push to a unique branch, so a new PR was opened daily. A fixed-name branch is the action's recommended usage: it reuses and updates a single open PR, hard-resetting the branch onto `main` each run.

### How to Test

Covered by the scheduled workflow: trigger it twice without merging in between and confirm the same open PR is updated rather than a second one opened.

### Jira

[DBI-1684](https://dailypay.atlassian.net/browse/DBI-1684)

[DBI-1684]: https://dailypay.atlassian.net/browse/DBI-1684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ